### PR TITLE
Need to read MILC dimensions into 32-bit structure

### DIFF
--- a/src/IO/read_headers.c
+++ b/src/IO/read_headers.c
@@ -174,8 +174,10 @@ get_header_data_MILC( FILE *in ,
   }
   
   // read in ND ints ... even though MILC only supports ND == 4 !!
-  if( fread( Latt.dims , sizeof(int) , ND , in ) != ND ) return GLU_FAILURE ;
-  if( need_swap ) { bswap_32( ND , Latt.dims ) ; }
+  int dimensions [ND];
+  if( fread( dimensions , sizeof(int) , ND , in ) != ND ) return GLU_FAILURE ;
+  if( need_swap ) { bswap_32( ND , dimensions ) ; } 
+  for (int i = 0; i < ND; i ++) Latt.dims[i] = dimensions[i];
 
   // date and time of creation is 64 bytes long ...
   char str[65] ;


### PR DESCRIPTION
When reading a MILC configuration, the current codebase tries to read 4 ints (16 bytes) directly into Latt.dims, but Latt.dims is an array of 4 size_t objects (32 bytes), which is too large to hold them.  In the current implementation, the x- and y-dimensions are read as being several billion, and z- and t-dimensions are both zero, so reading a MILC configuration fails.  By storing into ints first, we can read the dimensions correctly and then copy these into the Latt.dims.