### PR TITLE
Analogous change to write_headers.c for MILC configs

### DIFF
--- a/src/IO/write_headers.c
+++ b/src/IO/write_headers.c
@@ -55,7 +55,7 @@ write_header_MILC( FILE *__restrict out ,
   swap_and_write_int( out , magic , 1 ) ;
 
   int dims[ ND ] ;
-  memcpy( dims , Latt.dims , ND * sizeof( int ) ) ;
+  for (int i = 0; i < ND; i ++) dims[i] = Latt.dims[i];
   swap_and_write_int( out , dims , ND ) ;
 
   char str[ 64 ] ;


### PR DESCRIPTION
I apologize that I should have checked the other side of the I/O pipeline before creating the last pull request, but the 32/64-bit conversion problem affects writing MILC headers as well.  Thank you for all your work maintaining GLU - it is really great software!